### PR TITLE
feature: add striptagscode option

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
   run:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-    - run: npm install
-    - run: npm run lint
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+      - run: npm install
+      - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ search:
 - **format** - the form of the page contents, options are:
   * **html** (Default) - original html string being minified.
   * **striptags** - original html string being minified, and remove all the tags.
+  * **striptagscode** - In addition to removing HTML tags, remove the code in the article and reduce the size。
   * **raw** - markdown text of each posts or pages.
 
 ## FAQ

--- a/lib/database.js
+++ b/lib/database.js
@@ -15,9 +15,17 @@ function savedb(article, config, isPost) {
       data.content = article._content;
     } else {
       data.content = article.content.replace(/<td class="gutter">.*?<\/td>/g, '');
+      // strip code and html tag
+      if (config.search.format === 'striptagscode') {
+        data.content = data.content.replace(/<figure class="highlight\s?.*">.*?<\/figure>/g, '');
+        data.content = stripHTML(data.content);
+      }
       if (config.search.format === 'striptags') {
         data.content = stripHTML(data.content);
       }
+      // remove all blank lines
+      data.content = data.content.replace(/\n(\n)*( )*(\n)*\n/g, '');
+
     }
   } else {
     data.content = '';
@@ -34,7 +42,7 @@ function savedb(article, config, isPost) {
   return data;
 }
 
-module.exports = function(locals, config) {
+module.exports = function (locals, config) {
   const searchfield = config.search.field;
   const database = [];
   if (searchfield === 'all' || searchfield === 'post') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-searchdb",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Seach data generator plugin for Hexo.",
   "main": "index",
   "files": [


### PR DESCRIPTION
#22  add new option `striptagscode` to remove all html tag and codes of article

移除代码之前：

```
$ ll public/search.xml
-rw-r--r--  1 fudenglong  staff   1.1M  5 10 12:20 public/search.xml
```

移除代码和空格之后：

```
$ ll public/search.xml
-rw-r--r--  1 fudenglong  staff   708K  5 10 12:21 public/search.xml
```